### PR TITLE
fix pkgbuild

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: TODO
+# Maintainer: WhiteFall <whitefall76@outlook.com>
 # Maintainer: asukaminato <asukaminato@nyan.eu.org>
 
 pkgname=supermemo-18.05

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,3 +1,6 @@
+# Maintainer: TODO
+# Maintainer: asukaminato <asukaminato@nyan.eu.org>
+
 pkgname=supermemo-18.05
 pkgver=1.4.0
 pkgrel=1
@@ -12,7 +15,7 @@ source=("${pkgname}-${pkgver}-${arch}.deb::https://github.com/Zacharia2/SuperMem
 sha512sums=('ed960be944258023a4be546808235ee2358d6ecdea827974a7e4c1b94259ee15dc3a4c6c435f47a4b062622c3f4fbf442e916333e685422e39d8ecc77cf62eaa')
 
 package() {
-        tar xpf data.tar.xz -C ${pkgdir}
+        tar xpf data.tar.zst -C ${pkgdir}
         # todo: fix permission problems
         # asked in archlinuxcn-group, tell me to give up, so let it go. At least it works.
 }

--- a/deb-package/usr/share/applications/SuperMemo18.05-winecfg.desktop
+++ b/deb-package/usr/share/applications/SuperMemo18.05-winecfg.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=SuperMemo18.05-winecfg
-Exec=env WINEARCH=win32 WINEPREFIX="/usr/share/SM18.05-WINE-Vessel" sm-wine winecfg
+Exec=env WINEARCH=win32 WINEPREFIX="/usr/share/SM18.05-WINE-Vessel" /usr/share/SM18.05-WINE-Vessel/Wine-x86_64-ubuntu.latest.AppImage winecfg
 Type=Application
 Categories=Education;
 StartupNotify=true

--- a/deb-package/usr/share/applications/SuperMemo18.05.desktop
+++ b/deb-package/usr/share/applications/SuperMemo18.05.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=SuperMemo 18.05
-Exec=env WINEARCH=win32 WINEPREFIX="/usr/share/SM18.05-WINE-Vessel" sm-wine /usr/share/SM18.05-WINE-Vessel/drive_c/SuperMemo/sm18.exe
+Exec=env WINEARCH=win32 WINEPREFIX="/usr/share/SM18.05-WINE-Vessel" /usr/share/SM18.05-WINE-Vessel/Wine-x86_64-ubuntu.latest.AppImage /usr/share/SM18.05-WINE-Vessel/drive_c/SuperMemo/sm18.exe
 Type=Application
 Categories=Education;
 StartupNotify=true


### PR DESCRIPTION
这样修好后可以安装了，但还有问题。

```sh
krunner[2076]: QCommandLineParser: argument list cannot be empty, it should contain at least the executable name
krunner[2076]: file:///usr/lib/qt/qml/org/kde/plasma/components.3/ToolTip.qml:57:9: QML Label: Binding loop detected for property>
krunner[3935]: /usr/bin/env: "sm-wine": 没有那个文件或目录
```

需要研究下怎么修。
